### PR TITLE
Fix unit test of persistence test

### DIFF
--- a/persistence/persistencetest/state_execution_local_queues_json_test.go
+++ b/persistence/persistencetest/state_execution_local_queues_json_test.go
@@ -234,7 +234,7 @@ func TestStateExecutionLocalQueuesTryConsumeForStateExecution_Any_consumed(t *te
 	stateExecutionLocalQueues.AddNewLocalQueueCommands(persistence.StateExecutionId{
 		StateId: "state_1", StateIdSequence: 1,
 	}, []xdbapi.LocalQueueCommand{
-		{QueueName: "q1", Count: ptr.Any(int32(1))}, {QueueName: "q2", Count: ptr.Any(int32(2))},
+		{QueueName: "q1", Count: ptr.Any(int32(1))}, {QueueName: "q2", Count: ptr.Any(int32(3))},
 	})
 
 	// Return UnconsumedMessageQueueCountMap as:
@@ -243,7 +243,7 @@ func TestStateExecutionLocalQueuesTryConsumeForStateExecution_Any_consumed(t *te
 	//
 	// and StateToLocalQueueCommandsMap["state_1-1"] as:
 	//
-	// (q1, 1), (q2, 2)
+	// (q1, 1), (q2, 3)
 
 	consumedMessages := stateExecutionLocalQueues.TryConsumeForStateExecution(persistence.StateExecutionId{
 		StateId: "state_1", StateIdSequence: 1,


### PR DESCRIPTION
## Why make this pull request?

[Explain why you are making this pull request and what problem it solves.]

## What has changed

[Summarize what components of the repo is updated]

[Link to xdb-apis/xdb-golang-sdk PRs if it's on top of any API changes]

- API change link: ...
- Golang SDK change link: ...
- Server Component 1: ...
- Server Component 2: ...

## How to test this pull request?

[If writing Integration test in Golang SDK repo, please provide link to the pull request of Golang SDK Repo]

[It's recommended to write integration test in Golang SDK repo, and enabled in this server repo first, 
without enabling in the SDK repo. After this PR is merged, enable and merge the integration test in the SDK repo]

[Alternatively if Java/other SDK repo is preferred, then just test locally against server PR. 
After the server PR is merged, merge the integration test in the SDK repo]

## Checklist before merge
[ ] If applicable, merge the xdb-apis/xdb-golang-sdk PRs to main branch
[ ] If applicable, merge the xdb-apis/xdb-apis PRs to main branch
[ ] Update `go.mod` to use the commitID of the main branches for xdb-apis/xdb-golang-sdk
